### PR TITLE
Dropped unsafe code from users segment by using 'users' crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,7 @@ dependencies = [
  "clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "flame 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "users 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -396,6 +397,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "users"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa35e768d4daf1d85733418a49fb42e10d7f633e394fccab4ab7aba897053fe2"
+"checksum users 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "caa2760fcc10a6ae2c2a35d41c5d69827e4663f0d3889ecfb4d60b343f4139df"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ clap = "2.29.2"
 
 [dependencies]
 clap = "2.29.2"
+users = "0.7.0"
 
 [dependencies.chrono]
 optional = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 #[macro_use] extern crate clap;
 #[cfg(feature = "git2")] extern crate git2;
 #[cfg(feature = "flame")] extern crate flame;
+extern crate users;
 
 mod cli;
 mod format;

--- a/src/segments/segment_user.rs
+++ b/src/segments/segment_user.rs
@@ -1,45 +1,26 @@
-use std::{
-    borrow::Cow,
-    os::raw::{c_char, c_int},
-    str
-};
-use {Powerline, Shell, Segment};
-
-extern "C" {
-    fn getuid() -> c_int;
-    fn getlogin_r(buf: *mut c_char, len: usize) -> c_int;
-}
+use std::borrow::Cow;
+use users;
+use {Powerline, Segment, Shell};
 
 pub fn segment_user(p: &mut Powerline) {
     let (mut bg, fg) = (p.theme.username_bg, p.theme.username_fg);
 
-    if unsafe { getuid() } == 0 {
+    let uid = users::get_current_uid();
+    if uid == 0 {
         bg = p.theme.username_root_bg;
     }
 
-    if p.shell == Shell::Bare {
-        // Yeah the optimal approach wouldn't be to use environment variables
-        // but then again it would be a lot more code (even if from a library),
-        // therefore *probably* slower.
-        // But then again I don't know.
-
-        // We don't want to dont_escape() here
-        let mut name = [0u8; 256];
-        let mut string = Cow::from("error");
-        if unsafe { getlogin_r(&mut name[0] as *mut _ as *mut c_char, name.len()) } == 0 {
-            let len = name.iter().position(|i| *i == 0).unwrap_or(name.len());
-
-            if let Ok(name) = str::from_utf8(&name[..len]) {
-                string = Cow::from(String::from(name));
-            }
-        }
-        p.segments.push(Segment::new(bg, fg, string));
-        return;
-    }
-
-    p.segments.push(Segment::new(bg, fg, match p.shell {
-        Shell::Bare => unreachable!(),
-        Shell::Bash => "\\u",
-        Shell::Zsh  => "%n"
-    }).dont_escape());
+    p.segments.push(match p.shell {
+        Shell::Bare => Segment::new(
+            bg,
+            fg,
+            if let Some(user) = users::get_user_by_uid(uid) {
+                Cow::from(String::from(user.name()))
+            } else {
+                Cow::from("error")
+            },
+        ),
+        Shell::Bash => Segment::new(bg, fg, "\\u").dont_escape(),
+        Shell::Zsh => Segment::new(bg, fg, "%n").dont_escape(),
+    });
 }


### PR DESCRIPTION
NOTE: This also fixed 'error' username detection on Arch Linux.

I have tested that there is no performance penalty.

Interestingly, the binary size didn't change even by a single bit (1,565,896 bytes before and after the patch).