### PR TITLE
Added custom character support to git and ssh segments

### DIFF
--- a/src/segments/segment_git.rs
+++ b/src/segments/segment_git.rs
@@ -111,13 +111,13 @@ pub fn segment_git(p: &mut Powerline) {
             if let Ok((ahead, behind)) = git.graph_ahead_behind(local, upstream) {
                 if ahead > 0 {
                     let mut ahead = if ahead == 1 { String::new() } else { ahead.to_string() };
-                    ahead.push('⬆');
+                    ahead.push(p.theme.git_ahead_char);
                     p.segments.push(Segment::new(p.theme.git_ahead_bg, p.theme.git_ahead_fg, ahead));
                 }
 
                 if behind > 0 {
                     let mut behind = if behind == 1 { String::new() } else { behind.to_string() };
-                    behind.push('⬇');
+                    behind.push(p.theme.git_behind_char);
                     p.segments.push(Segment::new(p.theme.git_behind_bg, p.theme.git_behind_fg, behind));
                 }
             }
@@ -172,22 +172,22 @@ pub fn segment_gitstage(p: &mut Powerline) {
 
     if staged > 0 {
         let mut string = if staged == 1 { String::with_capacity(1) } else { staged.to_string() };
-        string.push('✔');
+        string.push(p.theme.git_staged_char);
         p.segments.push(Segment::new(p.theme.git_staged_bg, p.theme.git_staged_fg, string));
     }
     if notstaged > 0 {
         let mut string = if notstaged == 1 { String::with_capacity(1) } else { notstaged.to_string() };
-        string.push('✎');
+        string.push(p.theme.git_notstaged_char);
         p.segments.push(Segment::new(p.theme.git_notstaged_bg, p.theme.git_notstaged_fg, string));
     }
     if untracked > 0 {
         let mut string = if untracked == 1 { String::with_capacity(1) } else { untracked.to_string() };
-        string.push('+');
+        string.push(p.theme.git_untracked_char);
         p.segments.push(Segment::new(p.theme.git_untracked_bg, p.theme.git_untracked_fg, string));
     }
     if conflicted > 0 {
         let mut string = if conflicted == 1 { String::with_capacity(1) } else { conflicted.to_string() };
-        string.push('*');
+        string.push(p.theme.git_conflicted_char);
         p.segments.push(Segment::new(p.theme.git_conflicted_bg, p.theme.git_conflicted_fg, string));
     }
 }

--- a/src/segments/segment_perms.rs
+++ b/src/segments/segment_perms.rs
@@ -9,6 +9,6 @@ extern "C" {
 
 pub fn segment_perms(p: &mut Powerline) {
     if unsafe { access(".\0".as_ptr() as *const c_char, W_OK) } != 0 {
-        p.segments.push(Segment::new(p.theme.ro_bg, p.theme.ro_fg, ""));
+        p.segments.push(Segment::new(p.theme.ro_bg, p.theme.ro_fg, p.theme.ro_char.to_string()));
     }
 }

--- a/src/segments/segment_ssh.rs
+++ b/src/segments/segment_ssh.rs
@@ -3,6 +3,6 @@ use {Powerline, Segment};
 
 pub fn segment_ssh(p: &mut Powerline) {
     if env::var("SSH_CLIENT").is_ok() {
-        p.segments.push(Segment::new(p.theme.ssh_bg, p.theme.ssh_fg, ""));
+        p.segments.push(Segment::new(p.theme.ssh_bg, p.theme.ssh_fg, p.theme.ssh_char.to_string()));
     }
 }


### PR DESCRIPTION
Characters can be entered directly or as their Unicode codepoint hex codes.

The way the themer switches between u8 and char is a bit hacky, but works fine. Some future plans if you're okay with them:

- add chars for the git segment (branch/tag/detached)
- add nerd font support (so people don't have to add multiple custom characters to their theme file)