### PR TITLE
Add `linebreak` module

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -4,10 +4,14 @@ use std::fmt;
 pub struct Fg(pub Shell, pub u8);
 impl fmt::Display for Fg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            Shell::Bare => write!(f, "\x1b[38;5;{}m", self.1),
-            Shell::Bash => write!(f, "\\[\\e[38;5;{}m\\]", self.1),
-            Shell::Zsh  => write!(f, "%{{\x1b[38;5;{}m%}}", self.1)
+        if self.1 == 0 {
+            Reset(self.0, true).fmt(f)
+        } else {
+            match self.0 {
+                Shell::Bare => write!(f, "\x1b[38;5;{}m", self.1),
+                Shell::Bash => write!(f, "\\[\\e[38;5;{}m\\]", self.1),
+                Shell::Zsh  => write!(f, "%{{\x1b[38;5;{}m%}}", self.1)
+            }
         }
     }
 }
@@ -15,10 +19,14 @@ impl fmt::Display for Fg {
 pub struct Bg(pub Shell, pub u8);
 impl fmt::Display for Bg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            Shell::Bare => write!(f, "\x1b[48;5;{}m", self.1),
-            Shell::Bash => write!(f, "\\[\\e[48;5;{}m\\]", self.1),
-            Shell::Zsh  => write!(f, "%{{\x1b[48;5;{}m%}}", self.1)
+        if self.1 == 0 {
+            Reset(self.0, false).fmt(f)
+        } else {
+            match self.0 {
+                Shell::Bare => write!(f, "\x1b[48;5;{}m", self.1),
+                Shell::Bash => write!(f, "\\[\\e[48;5;{}m\\]", self.1),
+                Shell::Zsh  => write!(f, "%{{\x1b[48;5;{}m%}}", self.1)
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,7 @@ fn main() {
             Module::Ssh => segments::segment_ssh(&mut p),
             Module::Time => segments::segment_time(&mut p, &time_format),
             Module::User => segments::segment_user(&mut p),
+            Module::LineBreak => segments::segment_linebreak(&mut p),
             Module::VirtualEnv => segments::segment_virtualenv(&mut p),
         }
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -14,6 +14,7 @@ pub const ALL: &[&str] = &[
     "time",
     "user",
     "virtualenv",
+    "linebreak",
 ];
 
 #[derive(PartialEq, Eq)]
@@ -31,6 +32,7 @@ pub enum Module {
     Time,
     User,
     VirtualEnv,
+    LineBreak,
 }
 
 impl FromStr for Module {
@@ -50,6 +52,7 @@ impl FromStr for Module {
             "time"       => Ok(Module::Time),
             "user"       => Ok(Module::User),
             "virtualenv" => Ok(Module::VirtualEnv),
+            "linebreak"  => Ok(Module::LineBreak),
             _          => Err(())
         }
     }

--- a/src/segments/mod.rs
+++ b/src/segments/mod.rs
@@ -101,6 +101,7 @@ impl Segment {
         match next {
             Some(next) if next.is_conditional() => {},
             Some(next) if next.bg == self.bg => print!("{}", Fg(shell, theme.separator_fg)),
+            Some(next) if self.bg == 0 => print!("{}{}",  Fg(shell, next.bg), Bg(shell, next.bg)),
             Some(next) => print!("{}{}",  Fg(shell, self.bg), Bg(shell, next.bg)),
             // Last tile resets colors
             None       => print!("{}{}{}",Fg(shell, self.bg), Reset(shell, false), Reset(shell, true))

--- a/src/segments/mod.rs
+++ b/src/segments/mod.rs
@@ -9,6 +9,7 @@ pub mod segment_ssh;
 pub mod segment_time;
 pub mod segment_user;
 pub mod segment_virtualenv;
+pub mod segment_linebreak;
 
 pub use self::segment_cwd::*;
 pub use self::segment_host::*;
@@ -21,6 +22,7 @@ pub use self::segment_ssh::*;
 pub use self::segment_time::*;
 pub use self::segment_user::*;
 pub use self::segment_virtualenv::*;
+pub use self::segment_linebreak::*;
 
 #[cfg(feature = "git2")] pub mod segment_git;
 #[cfg(feature = "git2")] pub use self::segment_git::*;
@@ -38,6 +40,7 @@ pub struct Segment {
     before: &'static str,
     after: &'static str,
     conditional: bool,
+    no_space_after: bool,
 
     escaped: bool,
     text: Cow<'static, str>
@@ -53,6 +56,7 @@ impl Segment {
             before: "",
             after: "",
             conditional: false,
+            no_space_after: false,
 
             escaped: false,
             text:  text.into()
@@ -77,6 +81,10 @@ impl Segment {
     pub fn is_conditional(&self) -> bool {
         self.conditional
     }
+    pub fn with_no_space_after(mut self) -> Self {
+        self.no_space_after = true;
+        self
+    }
     pub fn escape(&mut self, shell: Shell) {
         if self.escaped {
             return;
@@ -85,7 +93,11 @@ impl Segment {
         self.escaped = true;
     }
     pub fn print(&self, next: Option<&Segment>, shell: Shell, theme: &Theme) {
-        print!("{}{}{} {} ", self.before, Fg(shell, self.fg), Bg(shell, self.bg), self.text);
+        print!("{}{}{} {}", self.before, Fg(shell, self.fg), Bg(shell, self.bg), self.text);
+
+        if !self.no_space_after {
+            print!(" ")
+        }
         match next {
             Some(next) if next.is_conditional() => {},
             Some(next) if next.bg == self.bg => print!("{}", Fg(shell, theme.separator_fg)),

--- a/src/segments/segment_linebreak.rs
+++ b/src/segments/segment_linebreak.rs
@@ -4,7 +4,7 @@ use crate::{Powerline, Segment, Shell};
 pub fn segment_linebreak(p: &mut Powerline) {
     let (bg, fg) = (0, 0);
     p.segments.push(match p.shell {
-        Shell::Bare => Segment::new(bg, fg, { Cow::from(String::from("\n")) }).with_no_space_after(),
+        Shell::Bare => Segment::new(bg, fg, "\n").dont_escape().with_no_space_after(),
         Shell::Bash => Segment::new(bg, fg, "\n").dont_escape().with_no_space_after(),
         Shell::Zsh => Segment::new(bg, fg, "\n").dont_escape().with_no_space_after(),
     });

--- a/src/segments/segment_linebreak.rs
+++ b/src/segments/segment_linebreak.rs
@@ -1,0 +1,11 @@
+use std::borrow::Cow;
+use crate::{Powerline, Segment, Shell};
+
+pub fn segment_linebreak(p: &mut Powerline) {
+    let (bg, fg) = (0, 0);
+    p.segments.push(match p.shell {
+        Shell::Bare => Segment::new(bg, fg, { Cow::from(String::from("\n")) }).with_no_space_after(),
+        Shell::Bash => Segment::new(bg, fg, "\n").dont_escape().with_no_space_after(),
+        Shell::Zsh => Segment::new(bg, fg, "\n").dont_escape().with_no_space_after(),
+    });
+}


### PR DESCRIPTION
<img width="407" alt="Screenshot 2020-02-08 at 16 03 25" src="https://user-images.githubusercontent.com/11493705/74088296-b02f7b00-4a8c-11ea-9851-afc0f2a8a2c4.png">

With a linebreak module, the prompt can show more information without decreasing the space one had to type in a single line. :)