### PR TITLE
added root user background

### DIFF
--- a/src/segments/segment_user.rs
+++ b/src/segments/segment_user.rs
@@ -5,12 +5,14 @@ pub fn segment_user(p: &mut Powerline) {
     let (bg, fg) = (p.theme.username_bg, p.theme.username_fg);
     #[cfg(feature = "users")]
     let mut bg = bg;
+    let mut fg = fg;
 
     #[cfg(feature = "users")]
     let uid = users::get_current_uid();
     #[cfg(feature = "users")]
     { if uid == 0 {
         bg = p.theme.username_root_bg;
+        fg = p.theme.username_root_fg;
     } }
 
     p.segments.push(match p.shell {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -11,6 +11,7 @@ pub struct Theme {
     pub username_bg: u8,
     pub username_fg: u8,
     pub username_root_bg: u8,
+    pub username_root_fg: u8,
     pub hostname_bg: u8,
     pub hostname_fg: u8,
 
@@ -81,6 +82,7 @@ pub const DEFAULT: Theme = Theme {
     username_bg: 240,
     username_fg: 250,
     username_root_bg: 124,
+    username_root_fg: 15,
     hostname_bg: 238,
     hostname_fg: 250,
 
@@ -200,6 +202,7 @@ fn theme_index_u8<'a>(theme: &'a mut Theme, name: &str) -> Option<&'a mut u8> {
         "username_bg" => Some(&mut theme.username_bg),
         "username_fg" => Some(&mut theme.username_fg),
         "username_root_bg" => Some(&mut theme.username_root_bg),
+        "username_root_fg" => Some(&mut theme.username_root_fg),
         "hostname_bg" => Some(&mut theme.hostname_bg),
         "hostname_fg" => Some(&mut theme.hostname_fg),
 


### PR DESCRIPTION
User root can have background and foreground different from root user. I simply needed this :)
![zsh-powerline-rs](https://user-images.githubusercontent.com/51510290/76215296-cda16180-6251-11ea-9999-d9c0c59b1919.PNG)

