### PR TITLE
--rtl option - print modules from right to left

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,4 +69,9 @@ pub fn build_cli() -> App<'static, 'static> {
                 .takes_value(true)
                 .value_name("file")
         )
+        .arg(
+            Arg::with_name("rtl")
+                .long("rtl")
+                .help("Print everything from right to left")
+            )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,15 +120,22 @@ fn main() {
     #[cfg(feature = "flame")]
     flame::start("print");
 
-    let n = p.segments.len();
-    for i in 1..n+1 {
-        p.segments[n-i].escape(p.shell);
-        p.segments[n-i].print(p.segments.get(n-i+1), p.shell, &p.theme);
+    if matches.is_present("rtl") {
+        let n = p.segments.len();
+        for i in 1..n+1 {
+            p.segments[n-i].escape(p.shell);
+            p.segments[n-i].print_rtl(p.segments.get(n-i+1), p.shell, &p.theme);
+        }
+    } else {
+        for i in 0..p.segments.len() {
+            p.segments[i].escape(p.shell);
+            p.segments[i].print(p.segments.get(i+1), p.shell, &p.theme);
+        }
     }
 
     if matches.is_present("newline") {
         println!();
-    } else {
+    } else if !matches.is_present("rtl") {
         print!(" ");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,9 +127,11 @@ fn main() {
             p.segments[n-i].print_rtl(p.segments.get(n-i+1), p.shell, &p.theme);
         }
     } else {
-        for i in 0..p.segments.len() {
-            p.segments[i].escape(p.shell);
-            p.segments[i].print(p.segments.get(i+1), p.shell, &p.theme);
+        for sublist in p.segments.windows(2) {
+            if let &[ref current, ref next] = sublist {
+                //current.escape(p.shell);
+                current.print(Some(next), p.shell, &p.theme);
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,9 +120,10 @@ fn main() {
     #[cfg(feature = "flame")]
     flame::start("print");
 
-    for i in 0..p.segments.len() {
-        p.segments[i].escape(p.shell);
-        p.segments[i].print(p.segments.get(i+1), p.shell, &p.theme);
+    let n = p.segments.len();
+    for i in 1..n+1 {
+        p.segments[n-i].escape(p.shell);
+        p.segments[n-i].print(p.segments.get(n-i+1), p.shell, &p.theme);
     }
 
     if matches.is_present("newline") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,11 +127,9 @@ fn main() {
             p.segments[n-i].print_rtl(p.segments.get(n-i+1), p.shell, &p.theme);
         }
     } else {
-        for sublist in p.segments.windows(2) {
-            if let &[ref current, ref next] = sublist {
-                //current.escape(p.shell);
-                current.print(Some(next), p.shell, &p.theme);
-            }
+        for i in 0..p.segments.len() {
+            p.segments[i].escape(p.shell);
+            p.segments[i].print(p.segments.get(i+1), p.shell, &p.theme);
         }
     }
 

--- a/src/segments/mod.rs
+++ b/src/segments/mod.rs
@@ -92,20 +92,18 @@ impl Segment {
         escape(shell, self.text.to_mut());
         self.escaped = true;
     }
-    pub fn print(&self, next: Option<&Segment>, shell: Shell, theme: &Theme) {
-        print!("{}{}{} {}", self.before, Fg(shell, self.fg), Bg(shell, self.bg), self.text);
-
+    pub fn print(&self, previous: Option<&Segment>, shell: Shell, theme: &Theme) {
+        print!("{}", self.after);
+        match previous {
+            Some(previous) if previous.is_conditional() => {},
+            Some(previous) if previous.bg == self.bg => print!("{}", Fg(shell, theme.separator_fg)),
+            Some(previous) => print!("{}{}",  Fg(shell, self.bg), Bg(shell, previous.bg)),
+            None       => print!("{}", Fg(shell, self.bg))
+        }
+        print!("{}{} {}", Fg(shell, self.fg), Bg(shell, self.bg), self.text);
         if !self.no_space_after {
             print!(" ")
         }
-        match next {
-            Some(next) if next.is_conditional() => {},
-            Some(next) if next.bg == self.bg => print!("{}", Fg(shell, theme.separator_fg)),
-            Some(next) if self.bg == 0 => print!("{}{}",  Fg(shell, next.bg), Bg(shell, next.bg)),
-            Some(next) => print!("{}{}",  Fg(shell, self.bg), Bg(shell, next.bg)),
-            // Last tile resets colors
-            None       => print!("{}{}{}",Fg(shell, self.bg), Reset(shell, false), Reset(shell, true))
-        }
-        print!("{}", self.after);
+        print!("{}{}{}", Reset(shell, false), Reset(shell, true), self.before);
     }
 }

--- a/src/segments/mod.rs
+++ b/src/segments/mod.rs
@@ -92,15 +92,33 @@ impl Segment {
         escape(shell, self.text.to_mut());
         self.escaped = true;
     }
-    pub fn print(&self, previous: Option<&Segment>, shell: Shell, theme: &Theme) {
+    pub fn print(&self, next: Option<&Segment>, shell: Shell, theme: &Theme) {
+        print!("{}{}{} {}", self.before, Fg(shell, self.fg), Bg(shell, self.bg), self.text);
+
+        if !self.no_space_after {
+            print!(" ")
+        }
+        match next {
+            Some(next) if next.is_conditional() => {},
+            Some(next) if next.bg == self.bg => print!("{}", Fg(shell, theme.separator_fg)),
+            Some(next) if self.bg == 0 => print!("{}{}",  Fg(shell, next.bg), Bg(shell, next.bg)),
+            Some(next) => print!("{}{}",  Fg(shell, self.bg), Bg(shell, next.bg)),
+            // Last tile resets colors
+            None       => print!("{}{}{}",Fg(shell, self.bg), Reset(shell, false), Reset(shell, true))
+        }
         print!("{}", self.after);
-        match previous {
-            Some(previous) if previous.is_conditional() => {},
-            Some(previous) if previous.bg == self.bg => print!("{}", Fg(shell, theme.separator_fg)),
-            Some(previous) => print!("{}{}",  Fg(shell, self.bg), Bg(shell, previous.bg)),
+    }
+    pub fn print_rtl(&self, next: Option<&Segment>, shell: Shell, theme: &Theme) {
+        // Here, next is going leftwards - see how this func is called in main.rs .
+        print!("{}", self.after);
+        match next {
+            Some(next) if next.is_conditional() => {},
+            Some(next) if next.bg == self.bg => print!("{}", Fg(shell, theme.separator_fg)),
+            Some(next) => print!("{}{}",  Fg(shell, self.bg), Bg(shell, next.bg)),
             None       => print!("{}", Fg(shell, self.bg))
         }
         print!("{}{} {}", Fg(shell, self.fg), Bg(shell, self.bg), self.text);
+
         if !self.no_space_after {
             print!(" ")
         }


### PR DESCRIPTION
Hello ! You mentioned on `powerline-rs`'s README that pull requests would be welcome, and I noticed that its github code had been updated more recently than its gitlab counterpart, so here I come with my PR.

This adds an `--rtl` option to `powerline-rs`, letting it print modules from right to left. While this should be usable for languages that work this way, I personally added this behaviour because I use it with zsh's `RPROMPT` option. See this screenshot :
![powerline-rs--rtl](https://user-images.githubusercontent.com/35574148/102120988-9052ab80-3e43-11eb-8e53-1bc93fa6ebee.png)

BTW my .zshrc extract looks like this :

``` zsh
# Remove the trailing space in RPROMPT. Used for compatibility with older terminals that would span a newline.
ZLE_RPROMPT_INDENT=0

pw_prompt() {
    PROMPT="$(powerline-rs --shell zsh --cwd-max-depth 2 --theme ~/.config/powerline-rs/tweaks.theme --modules host,cwd,root $?)"
    RPROMPT="$(powerline-rs --rtl --shell zsh --theme ~/.config/powerline-rs/tweaks.theme --modules git,gitstage)"
    # Jump back to cwd on new vte-terminal open :
    if test "$VTE_VERSION" && test -x /usr/lib/vte-urlencode-cwd; then
        printf "\033]7;file://%s%s\033\\" "${HOST}" "$(/usr/lib/vte-urlencode-cwd)"
    fi
}
if $(which powerline-rs); then
    precmd_functions+=(pw_prompt)
fi
```

Hope you like this contribution ! I think it could be taken even further by letting the `cwd` module also print from right to left when called ; I guess it wouldn't do it magically :) Tell me if you are interested, I could certainly implement that.

Regards,

la Fleur