### PR TITLE
Add CLI option to disable CWD module elipsis.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,12 @@ pub fn build_cli() -> App<'static, 'static> {
                 .default_value("15")
         )
         .arg(
+            Arg::with_name("cwd-no-ellipsis")
+                .long("cwd-no-ellipsis")
+                .help("Disable ellipsis when path component is too long.")
+                .takes_value(false)
+        )
+        .arg(
             Arg::with_name("error")
                 .help("Exit code of previously executed command")
                 .default_value("0")

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ fn main() {
 
     let cwd_max_depth    = value_t_or_exit!(matches, "cwd-max-depth", u8);
     let cwd_max_dir_size = value_t_or_exit!(matches, "cwd-max-dir-size", u8);
+    let cwd_no_ellipsis  = matches.is_present("cwd-no-ellipsis");
     let error            = value_t_or_exit!(matches, "error", u8);
 
     #[cfg(feature = "flame")]
@@ -98,7 +99,7 @@ fn main() {
 
     for module in modules {
         match module {
-            Module::Cwd => segments::segment_cwd(&mut p, cwd_max_depth, cwd_max_dir_size),
+            Module::Cwd => segments::segment_cwd(&mut p, cwd_max_depth, cwd_max_dir_size, cwd_no_ellipsis),
             Module::Git => { #[cfg(feature = "git2")] segments::segment_git(&mut p) },
             Module::GitStage => { #[cfg(feature = "git2")] segments::segment_gitstage(&mut p) },
             Module::Host => segments::segment_host(&mut p),

--- a/src/segments/segment_cwd.rs
+++ b/src/segments/segment_cwd.rs
@@ -6,7 +6,7 @@ use std::{
     path::PathBuf
 };
 
-pub fn segment_cwd(p: &mut Powerline, cwd_max_depth: u8, cwd_max_dir_size: u8) {
+pub fn segment_cwd(p: &mut Powerline, cwd_max_depth: u8, cwd_max_dir_size: u8, cwd_no_ellipsis: bool) {
     let mut path = env::current_dir().unwrap_or_else(|_| PathBuf::from("error"));
     if let Some(home) = dirs::home_dir() {
         let mut new_path = None;
@@ -28,7 +28,7 @@ pub fn segment_cwd(p: &mut Powerline, cwd_max_depth: u8, cwd_max_dir_size: u8) {
     if cwd_max_depth != 1 {
         if let Some(dir) = dirs.next() {
             // Either there's no cwd_max_depth, or it's bigger than 1
-            segment(p, dir, length == 1, cwd_max_dir_size);
+            segment(p, dir, length == 1, cwd_max_dir_size, cwd_no_ellipsis);
 
             // It would be sane here to subtract 1 from both length and
             // cwd_max_depth, to make it clear that we already tried one and
@@ -48,10 +48,10 @@ pub fn segment_cwd(p: &mut Powerline, cwd_max_depth: u8, cwd_max_dir_size: u8) {
     while let Some(cursor) = next {
         next = dirs.next();
 
-        segment(p, cursor, next.is_none(), cwd_max_dir_size);
+        segment(p, cursor, next.is_none(), cwd_max_dir_size, cwd_no_ellipsis);
     }
 }
-pub fn segment(p: &mut Powerline, name: &OsStr, last: bool, cwd_max_dir_size: u8) {
+pub fn segment(p: &mut Powerline, name: &OsStr, last: bool, cwd_max_dir_size: u8, cwd_no_ellipsis: bool) {
     let mut name = name.to_string_lossy().into_owned();
 
     let cwd_max_dir_size = cwd_max_dir_size as usize;
@@ -61,7 +61,9 @@ pub fn segment(p: &mut Powerline, name: &OsStr, last: bool, cwd_max_dir_size: u8
             start += c.len_utf8();
         }
         name.drain(start..);
-        name.push('…');
+        if !cwd_no_ellipsis {
+            name.push('…');
+        }
     }
 
     let fg = if last { p.theme.cwd_fg } else { p.theme.path_fg };


### PR DESCRIPTION
When a folder name is too long, CWD cuts it to cwd_max_dir_size
and adds an ellipsis (...).
This new option (--cwd-no-ellipsis) removes this ellipsis.