### PR TITLE
fix: Fixed displaying black foreground color after `linebreak` module broke it

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -4,7 +4,7 @@ use std::fmt;
 pub struct Fg(pub Shell, pub u8);
 impl fmt::Display for Fg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.1 == 0 {
+        if self.1 == 7 {
             Reset(self.0, true).fmt(f)
         } else {
             match self.0 {

--- a/src/segments/segment_linebreak.rs
+++ b/src/segments/segment_linebreak.rs
@@ -2,7 +2,8 @@ use std::borrow::Cow;
 use crate::{Powerline, Segment, Shell};
 
 pub fn segment_linebreak(p: &mut Powerline) {
-    let (bg, fg) = (0, 0);
+    // Use default bg and fg colors to avoid any coloring (Reset will be applied, see `format.rs`)
+    let (bg, fg) = (0, 7);
     p.segments.push(match p.shell {
         Shell::Bare => Segment::new(bg, fg, "\n").dont_escape().with_no_space_after(),
         Shell::Bash => Segment::new(bg, fg, "\n").dont_escape().with_no_space_after(),


### PR DESCRIPTION
```
$ ./target/release/powerline-rs --shell bare --modules 'ps,ssh,time,cwd,perms,git,gitstage,root,virtualenv' --cwd-max-dir-size 40 --time_format '%H:%M' 0
```

Before:

<img width="709" alt="image" src="https://user-images.githubusercontent.com/304265/215522200-a493ab62-74bf-4416-8255-60dfe584f85e.png">

After:

<img width="712" alt="image" src="https://user-images.githubusercontent.com/304265/215522276-6338ea19-59d4-41c3-96ba-f4f0f765588d.png">

Just for reference, the bug was introduced in #15.

cc @lazamar 